### PR TITLE
remove useless read 0 and fix tripouille

### DIFF
--- a/get_next_line.c
+++ b/get_next_line.c
@@ -42,6 +42,7 @@ char	*read_fd(int fd, char *line)
 		if (bytes == -1)
 		{
 			free(buffer);
+			free(line);
 			return (NULL);
 		}
 		buffer[bytes] = '\0';
@@ -104,7 +105,7 @@ char	*get_next_line(int fd)
 	static char	*buffer[10496];
 	char		*line;
 
-	if (fd == -1 || BUFFER_SIZE <= 0 || read(fd, 0, 0) < 0)
+	if (fd == -1 || BUFFER_SIZE <= 0)
 		return (NULL);
 	buffer[fd] = read_fd(fd, buffer[fd]);
 	if (!buffer[fd])

--- a/get_next_line_bonus.c
+++ b/get_next_line_bonus.c
@@ -43,6 +43,7 @@ char	*read_fd(int fd, char *line)
 		if (bytes == -1)
 		{
 			free(buffer);
+			free(line);
 			return (NULL);
 		}
 		buffer[bytes] = '\0';
@@ -105,7 +106,7 @@ char	*get_next_line(int fd)
 	static char	*buffer[10496];
 	char		*line;
 
-	if (fd == -1 || BUFFER_SIZE <= 0 || read(fd, 0, 0) < 0)
+	if (fd == -1 || BUFFER_SIZE <= 0)
 		return (NULL);
 	buffer[fd] = read_fd(fd, buffer[fd]);
 	if (!buffer[fd])


### PR DESCRIPTION
- You use `read(fd, 0, 0)` to check if the fd is usable but this check is useless, if the file is deleted between your first read and the real read you can crash.
- You need to handle the error when your really use read,